### PR TITLE
chore: update beam-model-rs dependency 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,0 @@
-[workspace]
-members = ["beam-model-rs", "flaredb"]
-resolver = "2"

--- a/flaredb/Cargo.toml
+++ b/flaredb/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-beam-model-rs = { path = "../beam-model-rs" }
+beam-model-rs = "2.70.0"
 tokio-stream = "0.1.18"
 tonic = "0.14.2"
 tokio = { version = "1.38", features = [


### PR DESCRIPTION
Since beam-model-rs is published as a standalone Rust crate, replaced the local workspace dependency with direct published create dependency.   