### PR TITLE
feat(flaredb): Node scheduler 

### DIFF
--- a/benchmarks/nexmarkgbk/src/main/java/com/flaredb/bench/NexmarkGBK.java
+++ b/benchmarks/nexmarkgbk/src/main/java/com/flaredb/bench/NexmarkGBK.java
@@ -155,7 +155,7 @@ public class NexmarkGBK {
         options.setRunner(FlareRunner.class);
         options.setJobEndpoint("127.0.0.1:8099");
         options.setUberJar(
-                "/home/ganesh/flare-db/manage-worker/flare-db/benchmarks/nexmarkgbk/target/nexmarkgbk-1.0-SNAPSHOT.jar");
+                "/home/ganesh/flare-db/schedule/flare-db/benchmarks/nexmarkgbk/target/nexmarkgbk-1.0-SNAPSHOT.jar");
 
         Pipeline p = Pipeline.create(options);
         NexmarkUtils.setupPipeline(NexmarkUtils.CoderStrategy.HAND, p);

--- a/flaredb/src/engine/executor.rs
+++ b/flaredb/src/engine/executor.rs
@@ -7,15 +7,19 @@ use std::{
 };
 
 use anyhow::{Error, anyhow};
+use async_trait::async_trait;
 use beam_model_rs::v1::{
-    ApiServiceDescriptor, Coder, Elements, FunctionSpec, PTransform, ProcessBundleDescriptor,
-    RemoteGrpcPort, elements,
+    ApiServiceDescriptor, Coder, Components, Elements, FunctionSpec, PTransform,
+    ProcessBundleDescriptor, RemoteGrpcPort, elements,
 };
 use bytes::{Buf, BytesMut};
 use log::{error, info};
 use petgraph::{Direction, graph::NodeIndex};
 use prost::Message;
-use tokio::sync::{Mutex, mpsc::UnboundedReceiver};
+use tokio::{
+    sync::{Mutex, mpsc::UnboundedReceiver},
+    task::JoinSet,
+};
 
 use crate::{
     engine::{
@@ -26,6 +30,7 @@ use crate::{
             log::LogChannel,
             state::StateChannel,
         },
+        scheduler::Scheduler,
     },
     fusion::{
         pipeline::{ConsumerMetaData, ExecutableGraph, ExecutableNode},
@@ -44,7 +49,7 @@ pub struct StageExecutor {
     log: LogChannel,
     state: StateChannel,
     pipeline_coders: Arc<HashMap<String, Coder>>,
-    graph: Option<ExecutableGraph>,
+    pipeline_components: Arc<Components>,
     store: Arc<FlareElementStore>,
     instance_id: String,
 }
@@ -67,7 +72,7 @@ impl StageExecutor {
             log,
             state,
             pipeline_coders: Arc::new(HashMap::new()),
-            graph: None,
+            pipeline_components: Arc::new(Components::default()),
             store,
             instance_id: instance_id.to_string(),
         })
@@ -85,9 +90,14 @@ impl StageExecutor {
         Ok(())
     }
 
-    /// Reset all harness channels so a new worker can connect.
-    /// Call this between jobs, after killing the old harness and before
-    /// spawning the new one.
+    pub fn prepare_pipeline(&mut self, pipeline_graph: &ExecutableGraph) {
+        // Start data channel to listening for elements.
+        self.data.stream_elements();
+        self.pipeline_coders = Arc::new(pipeline_graph.components.coders.clone());
+        self.pipeline_components = Arc::new(pipeline_graph.components.clone());
+    }
+
+    /// Reset all channels so a new worker can connect.
     pub async fn reset_channels(&self) {
         self.control.reset().await;
         self.data.reset().await;
@@ -96,85 +106,72 @@ impl StageExecutor {
         //self.store.reset();
         log::info!("stage executor channels reset");
     }
+}
 
-    pub async fn execute_pipeline(
+#[async_trait]
+pub trait Executor {
+    async fn execute(
         &mut self,
-        pipeline_graph: &ExecutableGraph,
-    ) -> Result<(), Error> {
-        info!("Starting to execute pipeline");
-        // Spin up channels to start listening for data from worker before node execution
-        self.data.stream_elements();
+        node: ExecutableNode,
+        input_edge_metadata: Option<ConsumerMetaData>,
+        output_edge_metadata: Option<ConsumerMetaData>,
+    ) -> anyhow::Result<ControlResponse>;
+}
 
-        let graph = pipeline_graph.get_executable_graph();
+#[async_trait]
+impl Executor for StageExecutor {
+    async fn execute(
+        &mut self,
+        node: ExecutableNode,
+        input_edge_metadata: Option<ConsumerMetaData>,
+        output_edge_metadata: Option<ConsumerMetaData>,
+    ) -> anyhow::Result<ControlResponse> {
+        self.execute_node(node, input_edge_metadata, output_edge_metadata, None)
+            .await
+    }
+}
 
-        self.pipeline_coders = Arc::new(pipeline_graph.components.coders.clone());
-        self.graph = Some(pipeline_graph.clone());
+pub async fn run_pipeline(
+    scheduler: &mut Scheduler,
+    executor: Arc<Mutex<StageExecutor>>,
+) -> anyhow::Result<()> {
+    let mut in_flight = JoinSet::new();
 
-        // Root node = node with no incoming edges
-        let root = graph
-            .node_indices()
-            .find(|&idx| {
-                graph
-                    .neighbors_directed(idx, Direction::Incoming)
-                    .next()
-                    .is_none()
-            })
-            .ok_or_else(|| anyhow::anyhow!("no root node found"))?;
+    loop {
+        for (idx, node) in scheduler.next_nodes() {
+            let executor = executor.clone();
+            let input_metadata = scheduler.input_edge_metadata(idx);
+            let output_metadata = scheduler.output_edge_metadata(idx);
 
-        let mut current_level = VecDeque::<NodeIndex>::new();
-        current_level.push_front(root);
-        // vec![root];
-
-        // executed nodes
-        let mut executed = HashSet::<NodeIndex>::new();
-
-        while !current_level.is_empty() {
-            let mut next_level = HashSet::<NodeIndex>::new();
-
-            // List of graph nodeindex and nodes in current level
-            let executable_nodes: Vec<(NodeIndex, ExecutableNode)> = current_level
-                .iter()
-                .map(|&idx| (idx, graph[idx].clone()))
-                .collect();
-            info!("Picked up nodes for current level ");
-
-            for (idx, node) in executable_nodes {
-                // Skip already executed nodes
-                // but there is a bug if we add it to the executed list but the node fail to execute
-                // then we'd produce an incorrect list, or we just fail eveything if the node fails
-                if !executed.insert(idx) {
-                    continue;
-                }
-
-                // previous stage -> current stage
-                let incoming_edge = graph
-                    .edges_directed(idx, Direction::Incoming)
-                    .next()
-                    .map(|e| e.weight().clone());
-
-                // current stage -> next stage
-                let outgoing_edge = graph
-                    .edges_directed(idx, Direction::Outgoing)
-                    .next()
-                    .map(|e| e.weight().clone());
-
-                // Execute node
-                self.execute_node(node, incoming_edge, outgoing_edge, None)
-                    .await?;
-
-                // Schedule downstream consumers
-                for downstream in graph.neighbors_directed(idx, Direction::Outgoing) {
-                    if !executed.contains(&downstream) {
-                        next_level.insert(downstream);
-                    }
-                }
-            }
-
-            current_level = next_level.into_iter().collect();
+            in_flight.spawn(async move {
+                let mut executor = executor.lock().await;
+                let result = executor
+                    .execute(node, input_metadata, output_metadata)
+                    .await;
+                (idx, result)
+            });
         }
-        Ok(())
+
+        if in_flight.is_empty() {
+            if scheduler.is_complete() {
+                break;
+            }
+            return Err(anyhow!(
+                "executable graph deadlocked: no ready nodes and no in-flight work"
+            ));
+        }
+
+        if let Some(joined) = in_flight.join_next().await {
+            let (idx, result) = joined?;
+            result?;
+            scheduler.mark_complete(idx);
+        }
     }
 
+    Ok(())
+}
+
+impl StageExecutor {
     pub async fn execute_node(
         &mut self,
         node: ExecutableNode,
@@ -333,77 +330,65 @@ impl StageExecutor {
             }
             ExecutableNode::Runner(runner_transform) => {
                 info!("Executing runner node");
-                if let Some(graph) = &self.graph {
-                    let input_metadata = input_edge_metadata.as_ref();
-                    let output_metadata = output_edge_metadata.as_ref();
-                    let root_metadata = graph.get_root_metadata();
 
-                    let input_pcollection_id =
-                        Self::metadata_pcollection_id(input_metadata, root_metadata);
-                    let output_pcollection_id = Self::runner_output_pcollection_id(
-                        &runner_transform,
-                        output_metadata,
-                        root_metadata,
-                    );
-                    let consumer_transfrom_id = Self::runner_consumer_transform_id(
-                        input_metadata,
-                        output_metadata,
-                        root_metadata,
-                    );
+                let input_metadata = input_edge_metadata.as_ref();
+                let output_metadata = output_edge_metadata.as_ref();
 
-                    info!("Runner node input metadata: {:?}", input_edge_metadata);
-                    info!("Runner node output metadata: {:?}", output_edge_metadata);
+                let input_pcollection_id = Self::metadata_pcollection_id(input_metadata);
+                let output_pcollection_id =
+                    Self::runner_output_pcollection_id(&runner_transform, output_metadata);
+                let consumer_transfrom_id =
+                    Self::runner_consumer_transform_id(input_metadata, output_metadata);
 
-                    let endpoint = ApiServiceDescriptor {
-                        url: crate::DEFAULT_API_SERVICE_URL.to_string(),
-                        ..Default::default()
-                    };
+                info!("Runner node input metadata: {:?}", input_edge_metadata);
+                info!("Runner node output metadata: {:?}", output_edge_metadata);
 
-                    let descriptor = ProcessBundleDescriptor {
-                        id: runner_transform.id(),
-                        transforms: runner_transform.transfrom_spec(),
-                        pcollections: runner_transform.pcollections(&graph.components),
-                        windowing_strategies: runner_transform.windowing_strategies(),
-                        coders: runner_transform.coders(),
-                        environments: runner_transform.environments(),
-                        state_api_service_descriptor: Some(endpoint.clone()),
-                        timer_api_service_descriptor: Some(endpoint),
-                    };
+                let endpoint = ApiServiceDescriptor {
+                    url: crate::DEFAULT_API_SERVICE_URL.to_string(),
+                    ..Default::default()
+                };
 
-                    let bundle_status = self.control.register_bundle(descriptor).await;
+                let descriptor = ProcessBundleDescriptor {
+                    id: runner_transform.id(),
+                    transforms: runner_transform.transfrom_spec(),
+                    pcollections: runner_transform.pcollections(&self.pipeline_components),
+                    windowing_strategies: runner_transform.windowing_strategies(),
+                    coders: runner_transform.coders(),
+                    environments: runner_transform.environments(),
+                    state_api_service_descriptor: Some(endpoint.clone()),
+                    timer_api_service_descriptor: Some(endpoint),
+                };
 
-                    match bundle_status {
-                        Ok(response) => {
-                            if matches!(response, ControlResponse::BundleRegistered) {
-                                info!("Runer bundle registred at worker");
-                                let ctx = ExecutionContext {
-                                    store: self.store.clone(),
-                                    input_pcollection_id,
-                                    output_pcollection_id,
-                                    consumer_transfrom_id,
-                                };
+                let bundle_status = self.control.register_bundle(descriptor).await;
 
-                                runner_transform.execute(ctx).await?;
-                            } else {
-                            }
+                match bundle_status {
+                    Ok(response) => {
+                        if matches!(response, ControlResponse::BundleRegistered) {
+                            info!("Runer bundle registred at worker");
+                            let ctx = ExecutionContext {
+                                store: self.store.clone(),
+                                input_pcollection_id,
+                                output_pcollection_id,
+                                consumer_transfrom_id,
+                            };
+
+                            runner_transform.execute(ctx).await?;
+                        } else {
                         }
-                        Err(err) => {
-                            return Err(anyhow!("Error while processing bundle {}", err));
-                        }
-                    };
-                }
+                    }
+                    Err(err) => {
+                        return Err(anyhow!("Error while processing bundle {}", err));
+                    }
+                };
 
                 Ok(ControlResponse::BundleDone)
             }
         }
     }
 
-    fn metadata_pcollection_id(
-        metadata: Option<&ConsumerMetaData>,
-        fallback_metadata: &ConsumerMetaData,
-    ) -> String {
+    fn metadata_pcollection_id(metadata: Option<&ConsumerMetaData>) -> String {
         metadata
-            .unwrap_or(fallback_metadata)
+            .expect("Runner node must have at least one available metadata source")
             .produced_pcol_id
             .clone()
     }
@@ -411,23 +396,22 @@ impl StageExecutor {
     fn runner_output_pcollection_id(
         runner_transform: &FlareRunnerTransform,
         output_metadata: Option<&ConsumerMetaData>,
-        root_metadata: &ConsumerMetaData,
     ) -> String {
         output_metadata
             .map(|meta| meta.produced_pcol_id.clone())
             .or_else(|| runner_transform.output_pcol_ids().into_iter().next())
-            .unwrap_or_else(|| root_metadata.produced_pcol_id.clone())
+            .expect("Runner transform must have an output pcollection id")
     }
 
     fn runner_consumer_transform_id(
         input_metadata: Option<&ConsumerMetaData>,
         output_metadata: Option<&ConsumerMetaData>,
-        root_metadata: &ConsumerMetaData,
     ) -> String {
         output_metadata
             .or(input_metadata)
-            .map(|meta| meta.consumer_transfrom_id.clone())
-            .unwrap_or_else(|| root_metadata.consumer_transfrom_id.clone())
+            .expect("Runner node must have available transform metadata")
+            .consumer_transfrom_id
+            .clone()
     }
 
     fn stage_source_transform_id(stage: &ExecutableStage) -> String {

--- a/flaredb/src/engine/executor.rs
+++ b/flaredb/src/engine/executor.rs
@@ -91,8 +91,11 @@ impl StageExecutor {
     }
 
     pub fn prepare_pipeline(&mut self, pipeline_graph: &ExecutableGraph) {
-        // Start data channel to listening for elements.
+        // Start data channel to listen for elements.
         self.data.stream_elements();
+        // Start control channel response dispatch so concurrent bundle waiters
+        // can receive messages safely.
+        self.control.stream_responses();
         self.pipeline_coders = Arc::new(pipeline_graph.components.coders.clone());
         self.pipeline_components = Arc::new(pipeline_graph.components.clone());
     }
@@ -145,6 +148,8 @@ pub async fn run_pipeline(
 
             in_flight.spawn(async move {
                 let mut executor = executor.lock().await;
+                // TODO: this fix makes ControlChannel safe for concurrent callers
+                // and unblocks switching to Arc<StageExecutor> in a later PR.
                 let result = executor
                     .execute(node, input_metadata, output_metadata)
                     .await;
@@ -194,7 +199,7 @@ impl StageExecutor {
                         if matches!(response, ControlResponse::BundleRegistered) {
                             info!("Bundle registered at worker");
 
-                            let instruction_id = self
+                            let (instruction_id, bundle_response_rx) = self
                                 .control
                                 .send_process_bundle_request(&descriptor_id)
                                 .await?;
@@ -236,8 +241,9 @@ impl StageExecutor {
                                     );
                                 }
                             });
-                            let bundle_response_future =
-                                self.control.recv_process_bundle_response(&instruction_id);
+                            let bundle_response_future = self
+                                .control
+                                .recv_process_bundle_response(&instruction_id, bundle_response_rx);
 
                             if let Some(output_meta_data) = output_meta_data {
                                 let data_key = DataKey {

--- a/flaredb/src/engine/executor.rs
+++ b/flaredb/src/engine/executor.rs
@@ -57,7 +57,7 @@ pub struct StageExecutor {
     pipeline_coders: Arc<HashMap<String, Coder>>,
     /// Pipeline components.
     pipeline_components: Arc<Components>,
-    /// Element storage (input/output sets for bundles).
+    /// Element storage
     store: Arc<FlareElementStore>,
     /// Instance ID
     instance_id: String,
@@ -157,8 +157,8 @@ pub async fn run_pipeline(
 
             in_flight.spawn(async move {
                 let mut executor = executor.lock().await;
-                // TODO: this fix makes ControlChannel safe for concurrent callers
-                // and unblocks switching to Arc<StageExecutor> in a later PR.
+                // TODO:  switch to Arc<StageExecutor>? since its mutex,
+                // each task may not be able to access the executor simultaneously.
                 let result = executor
                     .execute(node, input_metadata, output_metadata)
                     .await;

--- a/flaredb/src/engine/executor.rs
+++ b/flaredb/src/engine/executor.rs
@@ -1,12 +1,12 @@
 use std::{
-    collections::{HashMap, HashSet, VecDeque},
+    collections::HashMap,
     io::Cursor,
     panic::{AssertUnwindSafe, catch_unwind},
     sync::Arc,
     time::{Duration, Instant},
 };
 
-use anyhow::{Error, anyhow};
+use anyhow::anyhow;
 use async_trait::async_trait;
 use beam_model_rs::v1::{
     ApiServiceDescriptor, Coder, Components, Elements, FunctionSpec, PTransform,
@@ -14,7 +14,6 @@ use beam_model_rs::v1::{
 };
 use bytes::{Buf, BytesMut};
 use log::{error, info};
-use petgraph::{Direction, graph::NodeIndex};
 use prost::Message;
 use tokio::{
     sync::{Mutex, mpsc::UnboundedReceiver},
@@ -43,14 +42,24 @@ use crate::{
     utils::batch_size_estimator::{BatchConfig, BatchSizeEstimator},
 };
 
+/// Executor managing worker communication and bundle processing.
+/// Owns control and data channels, coordinates input/output element flow.
 pub struct StageExecutor {
+    /// Control plane
     control: ControlChannel,
+    /// Data plane
     data: DataChannel,
+    /// Logging channel
     log: LogChannel,
+    /// State API channel.
     state: StateChannel,
+    /// Pipeline coders.
     pipeline_coders: Arc<HashMap<String, Coder>>,
+    /// Pipeline components.
     pipeline_components: Arc<Components>,
+    /// Element storage (input/output sets for bundles).
     store: Arc<FlareElementStore>,
+    /// Instance ID
     instance_id: String,
 }
 
@@ -90,11 +99,11 @@ impl StageExecutor {
         Ok(())
     }
 
+    /// Start dispatcher tasks
     pub fn prepare_pipeline(&mut self, pipeline_graph: &ExecutableGraph) {
-        // Start data channel to listen for elements.
+        // Start data channel dispatcher to listen and demux incoming elements.
         self.data.stream_elements();
-        // Start control channel response dispatch so concurrent bundle waiters
-        // can receive messages safely.
+        // Start control channel dispatcher to route responses to waiting futures.
         self.control.stream_responses();
         self.pipeline_coders = Arc::new(pipeline_graph.components.coders.clone());
         self.pipeline_components = Arc::new(pipeline_graph.components.clone());
@@ -177,6 +186,7 @@ pub async fn run_pipeline(
 }
 
 impl StageExecutor {
+    /// Execute a worker or runner stage node.
     pub async fn execute_node(
         &mut self,
         node: ExecutableNode,
@@ -206,6 +216,7 @@ impl StageExecutor {
 
                             info!("Process instruction id {}", instruction_id);
 
+                            // Spawn background task to send input elements to worker.
                             if let Some(meta_data) = &input_edge_metadata {
                                 info!("Input edge metadata: {:?}", meta_data.clone());
                             }
@@ -630,7 +641,7 @@ impl StageExecutor {
                 let mut receiver_lock = receiver.lock().await;
                 receiver_lock.recv().await
             };
-            // ToDo create per bundle schema instred of derivsing schema for eveyry record batch.
+            // ToDo: create per bundle schema instred of deriving schema for eveyry record batch.
             // create paimon writer and commitor per bundle
             match payload {
                 Some(ElementStreamPayload::Data(data_chunk)) => {
@@ -694,7 +705,7 @@ impl StageExecutor {
                                         stream_buffer.len()
                                     ));
                                 }
-                                // Cursor is dropped; stream_buffer was never advanced.
+                                // Cursor is dropped stream_buffer was never advanced.
                                 break;
                             }
                         }
@@ -742,9 +753,8 @@ impl StageExecutor {
         Ok(())
     }
 
-    // Sends current stage's input elements to worker
-    pub async fn process_input_elements(ctx: ProcessInputContext) -> anyhow::Result<()> {
-        info!("Spawnned task to send stage's input elemenets to worker");
+    async fn process_input_elements(ctx: ProcessInputContext) -> anyhow::Result<()> {
+        info!("Spawned task to send stage's input elements to worker");
         info!(
             "Sending input elements: instruction_id={}, transform_id={}",
             ctx.input_instruction_id, ctx.consumer_transform_id,
@@ -785,6 +795,7 @@ impl StageExecutor {
     }
 }
 
+/// Context for process_input_elements task
 pub struct ProcessInputContext {
     input_stream: DataChannel,
     store: Arc<FlareElementStore>,

--- a/flaredb/src/engine/harness/control.rs
+++ b/flaredb/src/engine/harness/control.rs
@@ -12,28 +12,22 @@ use tokio::sync::{Mutex, mpsc, oneshot};
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::{Response, Status};
 
-// Shared inner state held in an Arc so both FlareControlService and
-// ControlChannel (owned by StageExecutor) see the same state.
-//
-// The outgoing channel is split into tx (sender, used by ControlChannel to
-// push InstructionRequests to the harness) and rx (receiver, handed to the
-// harness gRPC stream via ReceiverStream).  Both are Option-wrapped so they
-// can be replaced when a job finishes and a fresh harness connects.
+/// Shared gRPC channel for sending instructions to the worker.
 pub struct ControlInner {
     // Sender — ControlChannel writes InstructionRequests here.
     pub outgoing_tx: Mutex<Option<mpsc::Sender<Result<InstructionRequest, Status>>>>,
 
     // Receiver — taken by FlareControlService::control() and handed to the
-    // harness as a ReceiverStream.
+    // worker as a ReceiverStream.
     pub outgoing_rx: Mutex<Option<mpsc::Receiver<Result<InstructionRequest, Status>>>>,
 
-    // Incoming gRPC stream from the harness (InstructionResponses).
+    // Incoming gRPC stream from the worker (InstructionResponses).
     pub incoming: Mutex<Option<tonic::Streaming<InstructionResponse>>>,
 
-    // ProcessBundleDescriptors registered with the harness.
+    // ProcessBundleDescriptors registered with the worker.
     pub descriptors: Mutex<HashMap<String, ProcessBundleDescriptor>>,
 
-    // Pending responses from the harness, keyed by instruction_id.
+    // Pending responses from the worker, keyed by instruction_id.
     pub pending: DashMap<String, oneshot::Sender<InstructionResponse>>,
 }
 
@@ -115,16 +109,16 @@ impl BeamFnControl for FlareControlService {
             *self.inner.incoming.lock().await = Some(request.into_inner());
 
             // Take the rx end of the request channel — this is the stream
-            // of InstructionRequests the harness will read.
+            // of InstructionRequests the worker will read.
             let rx = {
                 let mut rx_guard = self.inner.outgoing_rx.lock().await;
-                // If outgoing_rx is None, a previous harness already took it
+                // If outgoing_rx is None, a previous worker already took it
                 // and disconnected without a clean reset. Create a fresh
-                // channel pair so the new harness gets a working stream
-                // instead of crashing with "harness connected twice".
+                // channel pair so the new worker gets a working stream
+                // instead of crashing with "worker connected twice".
                 if rx_guard.is_none() {
                     warn!(
-                        "Control stream connected while a previous harness stream was still active; replacing stale stream"
+                        "Control stream connected while a previous worker stream was still active; replacing stale stream"
                     );
                     let (tx, rx) = mpsc::channel::<Result<InstructionRequest, Status>>(32);
                     *self.inner.outgoing_tx.lock().await = Some(tx);
@@ -132,7 +126,7 @@ impl BeamFnControl for FlareControlService {
                 }
                 // Take ownership of the receiver and return it as a streaming
                 // gRPC response. After this, outgoing_rx is None again until
-                // the harness is reset for the next job.
+                // the worker is reset for the next job.
                 rx_guard
                     .take()
                     .expect("control outgoing receiver must be initialized")
@@ -189,11 +183,11 @@ pub enum ControlResponse {
     BundleDone,
 }
 
-/// ControlChannel: Flare → harness  (InstructionRequests)
-///                harness → Flare  (InstructionResponses, via inner.incoming)
+/// ControlChannel: Flare → worker  (InstructionRequests)
+///                worker → Flare  (InstructionResponses, via inner.incoming)
 ///
 /// The sender lives inside the shared `ControlInner` so it can be replaced
-/// when a harness disconnects and a new one connects.
+/// when a worker disconnects and a new one connects.
 #[derive(Clone)]
 pub struct ControlChannel {
     /// Shared state with FlareControlService (the gRPC handler).
@@ -201,14 +195,14 @@ pub struct ControlChannel {
     pub next_id: u64,
     /// Handle to the background response dispatch task. Aborted and awaited on
     /// during reset so a stale task from the previous job does not race with
-    /// the new harness stream.
+    /// the new worker stream.
     response_task: Arc<std::sync::Mutex<Option<tokio::task::JoinHandle<()>>>>,
 }
 
 impl ControlChannel {
-    // wait for harness to connect
+    // wait for worker to connect
     // poll until control() fires and stores the incoming stream
-    /// Wait for the harness to connect its control stream.
+    /// Wait for the worker to connect its control stream.
     pub async fn wait_connected(&self) -> Result<()> {
         loop {
             if self.stream.incoming.lock().await.is_some() {
@@ -218,11 +212,11 @@ impl ControlChannel {
         }
     }
 
-    // Reset the control channel so a new harness can connect.
+    // Reset the control channel so a new worker can connect.
     //
     // Creates a fresh mpsc pair, clears the incoming stream, and drops all
     // previously registered descriptors.  Call this between jobs (after
-    // killing the old harness, before spawning the new one).
+    // killing the old worker, before spawning the new one).
     pub async fn reset(&self) {
         let handle = self.response_task.lock().unwrap().take();
         if let Some(handle) = handle {
@@ -238,10 +232,10 @@ impl ControlChannel {
         self.stream.descriptors.lock().await.clear();
         self.stream.pending.clear();
 
-        log::info!("control channel reset for next harness");
+        log::info!("control channel reset for next worker");
     }
 
-    // register stage descriptor with harness
+    // register stage descriptor with worker
     // sends InstructionRequest { register: descriptor }
     // waits for InstructionResponse ack
     // called once per stage at startup
@@ -276,7 +270,7 @@ impl ControlChannel {
         // wait for ack
         let response = response_rx.await.map_err(|_| {
             anyhow!(
-                "control dispatcher reset or harness disconnected while awaiting register ack {}",
+                "control dispatcher reset or worker disconnected while awaiting register ack {}",
                 id
             )
         })?;
@@ -295,14 +289,14 @@ impl ControlChannel {
             }
             other => {
                 if !response.error.is_empty() {
-                    return Err(anyhow!("register failed at harness: {}", response.error));
+                    return Err(anyhow!("register failed at worker: {}", response.error));
                 }
                 Err(anyhow!("unexpected register response: {:?}", other))
             }
         }
     }
 
-    // tell harness to start a bundle
+    // tell worker to start a bundle
     // sends InstructionRequest { process_bundle: descriptor_id }
     // returns bundle_id so caller can match the response later
     // called every bundle
@@ -334,7 +328,7 @@ impl ControlChannel {
         Ok((id, response_rx))
     }
 
-    // wait for harness to confirm bundle complete
+    // wait for worker to confirm bundle complete
     // blocks until ProcessBundleResponse arrives on control channel
     // called after sending elements on data channel
     pub async fn recv_process_bundle_response(
@@ -345,7 +339,7 @@ impl ControlChannel {
         info!("Polling for process bundle response");
         let response = response_rx.await.map_err(|_| {
             anyhow!(
-                "control dispatcher reset or harness disconnected while awaiting instruction {}",
+                "control dispatcher reset or worker disconnected while awaiting instruction {}",
                 bundle_id
             )
         })?;
@@ -365,7 +359,7 @@ impl ControlChannel {
             other => {
                 if !response.error.is_empty() {
                     return Err(anyhow!(
-                        "process bundle failed at harness: {}",
+                        "process bundle failed at worker: {}",
                         response.error
                     ));
                 }
@@ -383,7 +377,7 @@ impl ControlChannel {
     pub fn stream_responses(&self) {
         let stream = self.stream.clone();
         let task_slot = self.response_task.clone();
-        info!("Streaming control responses from harness");
+        info!("Streaming control responses from worker");
 
         let join_handle = tokio::spawn(async move {
             loop {
@@ -417,17 +411,17 @@ impl ControlChannel {
                         continue;
                     }
                     Ok(None) => {
-                        info!("BeamFnControl stream from harness closed cleanly");
+                        info!("BeamFnControl stream from worker closed cleanly");
                         break;
                     }
                     Err(e) => {
-                        warn!("BeamFnControl stream error (harness gone?): {}", e);
+                        warn!("BeamFnControl stream error (worker gone?): {}", e);
                         break;
                     }
                 }
             }
 
-            info!("BeamFnControl stream from harness closed");
+            info!("BeamFnControl stream from worker closed");
         });
 
         *task_slot.lock().unwrap() = Some(join_handle);

--- a/flaredb/src/engine/harness/control.rs
+++ b/flaredb/src/engine/harness/control.rs
@@ -6,8 +6,9 @@ use beam_model_rs::v1::{
     ProcessBundleDescriptor, ProcessBundleRequest, ProcessBundleResponse, RegisterRequest,
     beam_fn_control_server::BeamFnControl, instruction_request,
 };
+use dashmap::DashMap;
 use log::{info, warn};
-use tokio::sync::{Mutex, mpsc};
+use tokio::sync::{Mutex, mpsc, oneshot};
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::{Response, Status};
 
@@ -31,6 +32,9 @@ pub struct ControlInner {
 
     // ProcessBundleDescriptors registered with the harness.
     pub descriptors: Mutex<HashMap<String, ProcessBundleDescriptor>>,
+
+    // Pending responses from the harness, keyed by instruction_id.
+    pub pending: DashMap<String, oneshot::Sender<InstructionResponse>>,
 }
 
 impl ControlInner {
@@ -54,13 +58,18 @@ pub async fn start_control_server() -> Result<(ControlChannel, FlareControlServi
         outgoing_rx: Mutex::new(Some(rx)),
         incoming: Mutex::new(None),
         descriptors: Mutex::new(HashMap::new()),
+        pending: DashMap::new(),
     });
 
     let service = FlareControlService {
         inner: stream.clone(),
     };
 
-    let channel = ControlChannel { stream, next_id: 0 };
+    let channel = ControlChannel {
+        stream,
+        next_id: 0,
+        response_task: Arc::new(std::sync::Mutex::new(None)),
+    };
 
     Ok((channel, service))
 }
@@ -190,6 +199,10 @@ pub struct ControlChannel {
     /// Shared state with FlareControlService (the gRPC handler).
     pub stream: Arc<ControlInner>,
     pub next_id: u64,
+    /// Handle to the background response dispatch task. Aborted and awaited on
+    /// during reset so a stale task from the previous job does not race with
+    /// the new harness stream.
+    response_task: Arc<std::sync::Mutex<Option<tokio::task::JoinHandle<()>>>>,
 }
 
 impl ControlChannel {
@@ -211,12 +224,19 @@ impl ControlChannel {
     // previously registered descriptors.  Call this between jobs (after
     // killing the old harness, before spawning the new one).
     pub async fn reset(&self) {
+        let handle = self.response_task.lock().unwrap().take();
+        if let Some(handle) = handle {
+            handle.abort();
+            let _ = handle.await;
+        }
+
         let (tx, rx) = mpsc::channel::<Result<InstructionRequest, Status>>(32);
 
         *self.stream.outgoing_tx.lock().await = Some(tx);
         *self.stream.outgoing_rx.lock().await = Some(rx);
         *self.stream.incoming.lock().await = None;
         self.stream.descriptors.lock().await.clear();
+        self.stream.pending.clear();
 
         log::info!("control channel reset for next harness");
     }
@@ -230,6 +250,7 @@ impl ControlChannel {
         descriptor: ProcessBundleDescriptor,
     ) -> Result<ControlResponse> {
         let id = self.next_id();
+        let response_rx = self.insert_pending_response(id.clone());
 
         self.stream
             .descriptors
@@ -238,18 +259,27 @@ impl ControlChannel {
             .insert(descriptor.id.clone(), descriptor.clone());
 
         let sender = self.stream.sender().await?;
-        sender
+        let send_result = sender
             .send(Ok(InstructionRequest {
                 instruction_id: id.clone(),
                 request: Some(instruction_request::Request::Register(RegisterRequest {
                     process_bundle_descriptor: vec![descriptor],
                 })),
             }))
-            .await
-            .map_err(|e| anyhow!("failed to send register request: {}", e))?;
+            .await;
+
+        if let Err(e) = send_result {
+            self.stream.pending.remove(&id);
+            return Err(anyhow!("failed to send register request: {}", e));
+        }
 
         // wait for ack
-        let response = self.recv_response().await?;
+        let response = response_rx.await.map_err(|_| {
+            anyhow!(
+                "control dispatcher reset or harness disconnected while awaiting register ack {}",
+                id
+            )
+        })?;
 
         if response.instruction_id != id {
             return Err(anyhow!(
@@ -276,16 +306,15 @@ impl ControlChannel {
     // sends InstructionRequest { process_bundle: descriptor_id }
     // returns bundle_id so caller can match the response later
     // called every bundle
-    pub async fn send_process_bundle_request(&mut self, descriptor_id: &String) -> Result<String> {
+    pub async fn send_process_bundle_request(
+        &mut self,
+        descriptor_id: &String,
+    ) -> Result<(String, oneshot::Receiver<InstructionResponse>)> {
         let id = self.next_id();
-
-        /* s let _endpoint = ApiServiceDescriptor {
-            url: "127.0.0.1:8099".to_string(),
-            ..Default::default()
-        };*/
+        let response_rx = self.insert_pending_response(id.clone());
 
         let sender = self.stream.sender().await?;
-        sender
+        let send_result = sender
             .send(Ok(InstructionRequest {
                 instruction_id: id.clone(),
                 request: Some(instruction_request::Request::ProcessBundle(
@@ -295,22 +324,31 @@ impl ControlChannel {
                     },
                 )),
             }))
-            .await
-            .map_err(|e| anyhow!("failed to send process bundle request: {}", e))?;
+            .await;
 
-        // return id — caller correlates with recv_process_bundle_response()
-        Ok(id)
+        if let Err(e) = send_result {
+            self.stream.pending.remove(&id);
+            return Err(anyhow!("failed to send process bundle request: {}", e));
+        }
+
+        Ok((id, response_rx))
     }
 
     // wait for harness to confirm bundle complete
     // blocks until ProcessBundleResponse arrives on control channel
     // called after sending elements on data channel
     pub async fn recv_process_bundle_response(
-        &mut self,
+        &self,
         bundle_id: &str,
+        response_rx: oneshot::Receiver<InstructionResponse>,
     ) -> Result<ControlResponse> {
         info!("Polling for process bundle response");
-        let response = self.recv_response().await?;
+        let response = response_rx.await.map_err(|_| {
+            anyhow!(
+                "control dispatcher reset or harness disconnected while awaiting instruction {}",
+                bundle_id
+            )
+        })?;
 
         if response.instruction_id != bundle_id {
             return Err(anyhow!(
@@ -336,22 +374,63 @@ impl ControlChannel {
         }
     }
 
-    // read next InstructionResponse from harness
-    // reads directly from the persisted gRPC stream
-    // no intermediate mpsc, no spawned tasks
-    // if stream dies → returns Err immediately, no deadlock
-    async fn recv_response(&self) -> Result<InstructionResponse> {
-        let mut guard = self.stream.incoming.lock().await;
+    fn insert_pending_response(&self, id: String) -> oneshot::Receiver<InstructionResponse> {
+        let (sender, receiver) = oneshot::channel();
+        self.stream.pending.insert(id, sender);
+        receiver
+    }
 
-        let stream = guard
-            .as_mut()
-            .ok_or_else(|| anyhow!("harness not connected yet"))?;
+    pub fn stream_responses(&self) {
+        let stream = self.stream.clone();
+        let task_slot = self.response_task.clone();
+        info!("Streaming control responses from harness");
 
-        stream
-            .message()
-            .await
-            .map_err(|e| anyhow!("control stream error: {}", e))?
-            .ok_or_else(|| anyhow!("harness disconnected"))
+        let join_handle = tokio::spawn(async move {
+            loop {
+                let response = {
+                    let mut guard = stream.incoming.lock().await;
+                    let Some(response_stream) = &mut *guard else {
+                        drop(guard);
+                        tokio::time::sleep(Duration::from_millis(10)).await;
+                        continue;
+                    };
+
+                    response_stream.message().await
+                };
+
+                match response {
+                    Ok(Some(response)) => {
+                        let instruction_id = response.instruction_id.clone();
+                        if let Some((_, sender)) = stream.pending.remove(&instruction_id) {
+                            if sender.send(response).is_err() {
+                                warn!(
+                                    "control response receiver dropped for instruction_id={}",
+                                    instruction_id
+                                );
+                            }
+                        } else {
+                            warn!(
+                                "no pending control receiver for instruction_id={}",
+                                instruction_id
+                            );
+                        }
+                        continue;
+                    }
+                    Ok(None) => {
+                        info!("BeamFnControl stream from harness closed cleanly");
+                        break;
+                    }
+                    Err(e) => {
+                        warn!("BeamFnControl stream error (harness gone?): {}", e);
+                        break;
+                    }
+                }
+            }
+
+            info!("BeamFnControl stream from harness closed");
+        });
+
+        *task_slot.lock().unwrap() = Some(join_handle);
     }
 
     // generate unique instruction ids

--- a/flaredb/src/engine/harness/data.rs
+++ b/flaredb/src/engine/harness/data.rs
@@ -15,9 +15,14 @@ use tokio::sync::{
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::{Response, Status};
 
+/// Shared gRPC channel state for data plane communication with the worker.
+/// Holds outgoing (Flare → worker) and incoming (worker → Flare) element streams.
 pub struct DataInner {
+    /// Sender for outgoing Elements stream to the worker.
     outgoing_tx: Mutex<Option<mpsc::Sender<Result<Elements, Status>>>>,
+    /// Receiver side of outgoing channel; handed to worker as gRPC stream.
     outgoing_rx: Mutex<Option<mpsc::Receiver<Result<Elements, Status>>>>,
+    /// Incoming Elements stream from worker; owned by stream_elements() dispatcher.
     incoming: Mutex<Option<tonic::Streaming<Elements>>>,
 }
 
@@ -51,9 +56,9 @@ pub async fn start_data_server() -> Result<(DataChannel, FlareDataService), anyh
     };
     Ok((channel, service))
 }
+/// gRPC server-side handler for BeamFnData service.
+/// Establishes the bidirectional gRPC stream with the worker.
 pub struct FlareDataService {
-    //sender: Arc<Mutex<Option<Sender<Result<Elements, Status>>>>>,
-    //incoming_tx: mpsc::Sender<Elements>,
     inner: Arc<DataInner>,
 }
 
@@ -61,7 +66,7 @@ impl BeamFnData for FlareDataService {
     #[doc = " Server streaming response type for the Data method."]
     type DataStream = ReceiverStream<Result<Elements, Status>>;
 
-    #[doc = " Used to send data between harnesses."]
+    #[doc = " Used to send data between workeres."]
     //#[must_use]
     #[allow(
         //elided_named_lifetimes,
@@ -84,14 +89,14 @@ impl BeamFnData for FlareDataService {
         Self: 'async_trait,
     {
         Box::pin(async move {
-            info!("BeamFnData stream connected from harness");
+            info!("BeamFnData stream connected from worker");
             *self.inner.incoming.lock().await = Some(request.into_inner());
 
             let rx = {
                 let mut rx_guard = self.inner.outgoing_rx.lock().await;
                 if rx_guard.is_none() {
                     warn!(
-                        "Data stream connected while a previous harness stream was still active; replacing stale stream"
+                        "Data stream connected while a previous worker stream was still active; replacing stale stream"
                     );
                     let (tx, rx) = mpsc::channel::<Result<Elements, Status>>(32);
                     *self.inner.outgoing_tx.lock().await = Some(tx);
@@ -107,13 +112,15 @@ impl BeamFnData for FlareDataService {
     }
 }
 
+/// Client-side data channel for executor to send/receive elements.
 #[derive(Clone)]
 pub struct DataChannel {
+    /// Shared gRPC stream state with FlareDataService.
     worker_stream: Arc<DataInner>,
+    /// Multiplexer routing incoming elements by (instruction_id, transform_id).
     runner_stream: Arc<ElementStreamMultiplexer>,
-    // Handle to the background streaming task.  Aborted and awaited on
-    // reset so a stale task from a previous job does not consume the
-    // new harness's data stream.
+    /// Handle to the background dispatcher task.
+    /// Aborted on reset to prevent stale task from consuming new worker stream.
     stream_task: Arc<std::sync::Mutex<Option<tokio::task::JoinHandle<()>>>>,
 }
 
@@ -123,13 +130,13 @@ impl DataChannel {
         sender
             .send(Ok(elements))
             .await
-            .map_err(|e| anyhow!("failed to send data-plane elements to harness: {}", e))
+            .map_err(|e| anyhow!("failed to send data-plane elements to worker: {}", e))
     }
 
-    // Reset the data channel so a new harness can connect.
+    // Reset the data channel so a new worker can connect.
     pub async fn reset(&self) {
         // Abort the streaming task from the previous job so it does not
-        // race with the new task to consume the incoming harness stream.
+        // race with the new task to consume the incoming worker stream.
         let handle = self.stream_task.lock().unwrap().take();
         if let Some(handle) = handle {
             handle.abort();
@@ -144,18 +151,20 @@ impl DataChannel {
         *self.worker_stream.incoming.lock().await = None;
 
         // Clear the element multiplexer — old entries from the previous
-        // harness are stale.
+        // worker are stale.
         self.runner_stream.senders().clear();
         self.runner_stream.receivers().clear();
 
-        log::info!("data channel reset for next harness");
+        log::info!("data channel reset for next worker");
     }
 
+    /// Start the background dispatcher task that routes incoming elements.
+    /// reads from incoming_stream and demuxes every message by (instruction_id, transform_id) to separate queues.
     pub fn stream_elements(&self) {
         let worker_data_stream = self.worker_stream.clone();
         let runner_stream = self.runner_stream.clone();
         let task_slot = self.stream_task.clone();
-        info!("Streaming elements from harness");
+        info!("Streaming elements from worker");
 
         let join_handle = tokio::spawn(async move {
             loop {
@@ -170,14 +179,15 @@ impl DataChannel {
                 loop {
                     match stream.message().await {
                         Ok(Some(elements)) => {
+                            // Demux Elements message into per-instruction queues
                             info!(
-                                "Received Elements from harness: data={}, timers={}",
+                                "Received Elements from worker: data={}, timers={}",
                                 elements.data.len(),
                                 elements.timers.len()
                             );
                             for data in elements.data {
                                 info!(
-                                    "Routing data from harness: instruction_id={}, transform_id={}, is_last={}, bytes={}",
+                                    "Routing data from worker: instruction_id={}, transform_id={}, is_last={}, bytes={}",
                                     data.instruction_id,
                                     data.transform_id,
                                     data.is_last,
@@ -188,8 +198,8 @@ impl DataChannel {
                                     transform_id: data.transform_id.clone(),
                                 };
 
+                                // Route to queue keyed by (instruction_id, transform_id)
                                 let element_key = ElementKey::Data(data_key.clone());
-
                                 let sender = Self::get_sender(element_key, &runner_stream);
 
                                 let _ = sender.send(ElementStreamPayload::Data(DataChunk {
@@ -214,17 +224,17 @@ impl DataChannel {
                             }
                         }
                         Ok(None) => {
-                            info!("BeamFnData stream from harness closed cleanly");
+                            info!("BeamFnData stream from worker closed cleanly");
                             break;
                         }
                         Err(e) => {
-                            warn!("BeamFnData stream error (harness gone?): {}", e);
+                            warn!("BeamFnData stream error (worker gone?): {}", e);
                             break;
                         }
                     }
                 }
 
-                info!("BeamFnData stream from harness closed");
+                info!("BeamFnData stream from worker closed");
                 break;
             }
         });
@@ -277,12 +287,14 @@ impl DataChannel {
     }
 }
 
+/// Key for routing data elements: (instruction_id, transform_id) pair.
 #[derive(PartialEq, Eq, Hash, Clone, Debug)]
 pub struct DataKey {
     pub(crate) instruction_id: String,
     pub(crate) transform_id: String,
 }
 
+/// Key for routing timer elements: instruction_id.
 #[derive(PartialEq, Eq, Hash, Clone)]
 pub struct TimersKey {
     pub(crate) instruction_id: String,
@@ -290,13 +302,19 @@ pub struct TimersKey {
     // pub(crate) timer_family_id: String,
 }
 
+/// Union type for routing keys: either data or timers.
 #[derive(PartialEq, Eq, Hash, Clone)]
 pub enum ElementKey {
     Data(DataKey),
     Timers(TimersKey),
 }
+
+/// Multiplexer that routes incoming elements to per-key unbounded channels.
+/// Each caller (executor, transform) registers a key and gets its own receiver queue.
 pub struct ElementStreamMultiplexer {
+    /// Senders for each element key; created on first access.
     senders: DashMap<ElementKey, UnboundedSender<ElementStreamPayload>>,
+    /// Corresponding receivers; one per key.
     receivers: DashMap<ElementKey, Arc<Mutex<UnboundedReceiver<ElementStreamPayload>>>>,
 }
 
@@ -319,32 +337,28 @@ impl ElementStreamMultiplexer {
     }
 }
 
+/// Payload sent through element queues: either data or timers.
 #[derive(Clone)]
 pub enum ElementStreamPayload {
-    // assuming we might need the data and timers in order
     Data(DataChunk),
     Timers(TimerChunk),
 }
 
+/// Data element with routing key.
 #[derive(Eq, Hash, PartialEq, Clone)]
 pub struct DataChunk {
     pub(crate) key: DataKey,
     pub(crate) data: Data,
 }
 
+/// Timer element with routing key.
 #[derive(Eq, Hash, PartialEq, Clone)]
 pub struct TimerChunk {
     pub(crate) key: TimersKey,
     pub(crate) timers: Timers,
 }
 
-// Flare control(process bundle request) -> harness
+// Flare control(process bundle request) -> worker
 //                                            | prcessed elements
 //                                    data channel(processed elements)
-// Flare --> inputs elements to harness ->    |
-
-/*
-one background task drains tonic stream
-routes elements by instruction_id
-bundle sessions receive their own outputs asynchronously
- */
+// Flare --> inputs elements to worker ->    |

--- a/flaredb/src/engine/mod.rs
+++ b/flaredb/src/engine/mod.rs
@@ -1,3 +1,4 @@
 pub mod coders;
 pub mod executor;
+pub mod scheduler;
 pub mod harness;

--- a/flaredb/src/engine/scheduler.rs
+++ b/flaredb/src/engine/scheduler.rs
@@ -1,0 +1,236 @@
+// Scheduler for executing an `ExecutableGraph`.
+//
+// The `Scheduler` iterates over nodes in an `ExecutableGraph` and tracks
+// which nodes have been executed and which are currently in-flight.
+//
+// It exposes methods to fetch next ready nodes, mark nodes complete, and
+// obtain input/output edge metadata. It's used by the engine to schedule
+// execution order while respecting data dependencies.
+
+use std::collections::HashSet;
+
+use petgraph::{Direction, graph::NodeIndex};
+
+use crate::fusion::pipeline::{ConsumerMetaData, ExecutableGraph, ExecutableNode};
+
+/// Scheduler that manages execution state for an `ExecutableGraph`.
+///
+/// Tracks executed and in-flight nodes and provides helpers to query ready
+/// nodes and edge metadata.
+pub struct Scheduler {
+    graph: ExecutableGraph,
+    executed: HashSet<NodeIndex>,
+    in_flight: HashSet<NodeIndex>,
+}
+
+impl Scheduler {
+    pub fn new(graph: ExecutableGraph) -> Self {
+        Self {
+            graph,
+            executed: HashSet::new(),
+            in_flight: HashSet::new(),
+        }
+    }
+
+    /// Returns the next ready nodes to execute.
+    ///
+    /// A node is considered ready when it is not in the `executed` or
+    /// `in_flight` sets and all of its predecessor nodes have been executed.
+    /// Nodes returned by this method are marked as in-flight.
+    pub fn next_nodes(&mut self) -> Vec<(NodeIndex, ExecutableNode)> {
+        let mut ready = Vec::new();
+
+        for idx in self.graph.get_executable_graph().node_indices() {
+            if self.executed.contains(&idx) || self.in_flight.contains(&idx) {
+                continue;
+            }
+
+            let all_predecessors_executed = self
+                .graph
+                .get_executable_graph()
+                .neighbors_directed(idx, Direction::Incoming)
+                .all(|pred| self.executed.contains(&pred));
+
+            if all_predecessors_executed {
+                self.in_flight.insert(idx);
+                ready.push((idx, self.graph.get_executable_graph()[idx].clone()));
+            }
+        }
+
+        ready
+    }
+
+    /// Marks a node as completed.
+    ///
+    /// Removes the node from the in-flight set and inserts it into the
+    /// executed set.
+    pub fn mark_complete(&mut self, idx: NodeIndex) {
+        self.in_flight.remove(&idx);
+        self.executed.insert(idx);
+    }
+
+    /// Returns metadata for an incoming edge to `idx`, if present.
+    ///
+    /// - If the node has an incoming edge, returns that edge's
+    ///   `ConsumerMetaData`.
+    /// - If the node has no predecessors (i.e. it's a root), returns the
+    ///   graph's root metadata.
+    /// - Otherwise returns `None`.
+    pub fn input_edge_metadata(&self, idx: NodeIndex) -> Option<ConsumerMetaData> {
+        let graph = self.graph.get_executable_graph();
+
+        if let Some(edge) = graph.edges_directed(idx, Direction::Incoming).next() {
+            return Some(edge.weight().clone());
+        }
+
+        if graph
+            .neighbors_directed(idx, Direction::Incoming)
+            .next()
+            .is_none()
+        {
+            return Some(self.root_metadata().clone());
+        }
+
+        None
+    }
+
+    /// Returns metadata for the first outgoing edge from `idx`, if any.
+    pub fn output_edge_metadata(&self, idx: NodeIndex) -> Option<ConsumerMetaData> {
+        self.graph
+            .get_executable_graph()
+            .edges_directed(idx, Direction::Outgoing)
+            .next()
+            .map(|edge| edge.weight().clone())
+    }
+
+    /// Returns the root `ConsumerMetaData` for the graph.
+    pub fn root_metadata(&self) -> &ConsumerMetaData {
+        self.graph.get_root_metadata()
+    }
+
+    /// Returns `true` when every node in the graph has been executed.
+    pub fn is_complete(&self) -> bool {
+        self.executed.len() == self.graph.get_executable_graph().node_count()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::{HashMap, HashSet};
+
+    use beam_model_rs::v1::Components;
+    use petgraph::Graph;
+
+    use crate::engine::scheduler::Scheduler;
+    use crate::fusion::pipeline::{ConsumerMetaData, ExecutableGraph, ExecutableNode};
+    use crate::jobservice::urns::beam_urns;
+    use crate::transforms::from_urn;
+
+    fn runner_node(name: &str) -> ExecutableNode {
+        ExecutableNode::Runner(from_urn(
+            beam_urns::IMPULSE_TRANSFORM,
+            name.to_string(),
+            HashMap::new(),
+            HashMap::new(),
+        ))
+    }
+
+    fn dummy_metadata(name: &str) -> ConsumerMetaData {
+        ConsumerMetaData {
+            producer_transform_id: format!("producer-{}", name),
+            produced_pcol_id: format!("pcol-{}", name),
+            coder_id: format!("coder-{}", name),
+            component_coder: None,
+            consumer_transfrom_id: format!("consumer-{}", name),
+        }
+    }
+
+    fn graph_for_test(
+        graph: Graph<ExecutableNode, ConsumerMetaData>,
+        root_metadata: ConsumerMetaData,
+    ) -> ExecutableGraph {
+        ExecutableGraph::from_graph_for_test(graph, root_metadata)
+    }
+
+    #[test]
+    fn next_nodes_linear_chain() {
+        let mut graph = Graph::<ExecutableNode, ConsumerMetaData>::new();
+        let a = graph.add_node(runner_node("A"));
+        let b = graph.add_node(runner_node("B"));
+        let c = graph.add_node(runner_node("C"));
+
+        graph.add_edge(a, b, dummy_metadata("ab"));
+        graph.add_edge(b, c, dummy_metadata("bc"));
+
+        let executable_graph = graph_for_test(graph, dummy_metadata("root"));
+        let mut scheduler = Scheduler::new(executable_graph);
+
+        let ready = scheduler.next_nodes();
+        assert_eq!(ready.len(), 1);
+        assert_eq!(ready[0].0, a);
+
+        scheduler.mark_complete(a);
+        let ready = scheduler.next_nodes();
+        assert_eq!(ready.len(), 0);
+
+        scheduler.mark_complete(b);
+        let ready = scheduler.next_nodes();
+        assert_eq!(ready.len(), 1);
+        assert_eq!(ready[0].0, c);
+    }
+
+    #[test]
+    fn next_nodes_fan_out() {
+        let mut graph = Graph::<ExecutableNode, ConsumerMetaData>::new();
+        let a = graph.add_node(runner_node("A"));
+        let b = graph.add_node(runner_node("B"));
+        let c = graph.add_node(runner_node("C"));
+
+        graph.add_edge(a, b, dummy_metadata("ab"));
+        graph.add_edge(a, c, dummy_metadata("ac"));
+
+        let executable_graph = graph_for_test(graph, dummy_metadata("root"));
+        let mut scheduler = Scheduler::new(executable_graph);
+
+        let ready = scheduler.next_nodes();
+        assert_eq!(ready.len(), 1);
+        assert_eq!(ready[0].0, a);
+
+        scheduler.mark_complete(a);
+        let mut ready = scheduler.next_nodes();
+        assert_eq!(ready.len(), 2);
+        let ready_indices: HashSet<_> = ready.into_iter().map(|(idx, _)| idx).collect();
+        assert!(ready_indices.contains(&b));
+        assert!(ready_indices.contains(&c));
+    }
+
+    #[test]
+    fn next_nodes_fan_in_requires_both_parents() {
+        let mut graph = Graph::<ExecutableNode, ConsumerMetaData>::new();
+        let a = graph.add_node(runner_node("A"));
+        let b = graph.add_node(runner_node("B"));
+        let c = graph.add_node(runner_node("C"));
+
+        graph.add_edge(a, c, dummy_metadata("ac"));
+        graph.add_edge(b, c, dummy_metadata("bc"));
+
+        let executable_graph = graph_for_test(graph, dummy_metadata("root"));
+        let mut scheduler = Scheduler::new(executable_graph);
+
+        let ready = scheduler.next_nodes();
+        assert_eq!(ready.len(), 2);
+        let ready_indices: HashSet<_> = ready.into_iter().map(|(idx, _)| idx).collect();
+        assert!(ready_indices.contains(&a));
+        assert!(ready_indices.contains(&b));
+
+        scheduler.mark_complete(a);
+        let ready = scheduler.next_nodes();
+        assert_eq!(ready.len(), 1);
+        assert_eq!(ready[0].0, b);
+
+        scheduler.mark_complete(b);
+        let ready = scheduler.next_nodes();
+        assert_eq!(ready.len(), 1);
+        assert_eq!(ready[0].0, c);
+    }
+}

--- a/flaredb/src/engine/scheduler.rs
+++ b/flaredb/src/engine/scheduler.rs
@@ -1,12 +1,3 @@
-// Scheduler for executing an `ExecutableGraph`.
-//
-// The `Scheduler` iterates over nodes in an `ExecutableGraph` and tracks
-// which nodes have been executed and which are currently in-flight.
-//
-// It exposes methods to fetch next ready nodes, mark nodes complete, and
-// obtain input/output edge metadata. It's used by the engine to schedule
-// execution order while respecting data dependencies.
-
 use std::collections::HashSet;
 
 use petgraph::{Direction, graph::NodeIndex};
@@ -118,7 +109,6 @@ impl Scheduler {
 mod tests {
     use std::collections::{HashMap, HashSet};
 
-    use beam_model_rs::v1::Components;
     use petgraph::Graph;
 
     use crate::engine::scheduler::Scheduler;
@@ -197,7 +187,7 @@ mod tests {
         assert_eq!(ready[0].0, a);
 
         scheduler.mark_complete(a);
-        let mut ready = scheduler.next_nodes();
+        let ready = scheduler.next_nodes();
         assert_eq!(ready.len(), 2);
         let ready_indices: HashSet<_> = ready.into_iter().map(|(idx, _)| idx).collect();
         assert!(ready_indices.contains(&b));

--- a/flaredb/src/fusion/pipeline.rs
+++ b/flaredb/src/fusion/pipeline.rs
@@ -268,6 +268,24 @@ impl ExecutableGraph {
     pub fn get_executable_graph(&self) -> &Graph<ExecutableNode, ConsumerMetaData> {
         &self.graph
     }
+
+    #[cfg(test)]
+    pub fn from_graph_for_test(
+        graph: Graph<ExecutableNode, ConsumerMetaData>,
+        root_metadata: ConsumerMetaData,
+    ) -> Self {
+        let mut node_indices = HashMap::new();
+        for idx in graph.node_indices() {
+            node_indices.insert(graph[idx].id(), idx);
+        }
+
+        Self {
+            graph,
+            node_indices,
+            components: Components::default(),
+            root_metadata: Some(root_metadata),
+        }
+    }
 }
 
 #[derive(Clone)]

--- a/flaredb/src/jobservice/server.rs
+++ b/flaredb/src/jobservice/server.rs
@@ -15,7 +15,8 @@ use tonic::Response;
 use tonic::Status;
 use uuid::Uuid;
 
-use crate::engine::executor::StageExecutor;
+use crate::engine::executor::{StageExecutor, run_pipeline};
+use crate::engine::scheduler::Scheduler;
 use crate::jobservice::artifact::ArtifactStore;
 use crate::jobservice::job::Job;
 use crate::jobservice::job::JobStore;
@@ -180,10 +181,13 @@ impl JobService for FlareJobService {
                 ))
             })?;
 
-            executor
-                .lock()
-                .await
-                .execute_pipeline(job_graph.as_ref())
+            {
+                let mut executor_guard = executor.lock().await;
+                executor_guard.prepare_pipeline(job_graph.as_ref());
+            }
+
+            let mut scheduler = Scheduler::new((*job_graph).clone());
+            run_pipeline(&mut scheduler, executor.clone())
                 .await
                 .map_err(|e| {
                     Status::internal(format!(
@@ -192,7 +196,7 @@ impl JobService for FlareJobService {
                     ))
                 })?;
 
-            // Kill the harness — the next job will get a fresh one.
+            // stop worker, next job will get a fresh one.
             self.worker_manager.stop_worker(&preparation_id).await?;
 
             log::info!("job execution completed: preparation_id={}", preparation_id);


### PR DESCRIPTION
Introduce a dedicated Scheduler to decouple node scheduling from execution, and refactor the Beam Fn Control channel to safely demultiplex responses for concurrent bundle execution.

Base for #19 