### PR TITLE
test: add unit tests for flarerunner module

### DIFF
--- a/runner-sdk/java/flarerunner/build.gradle
+++ b/runner-sdk/java/flarerunner/build.gradle
@@ -16,6 +16,8 @@ dependencies {
     implementation libs.beam.core
     implementation libs.beam.runners.portability
     implementation libs.slf4j.api
+
+    testImplementation libs.junit
 }
 
 spotless {

--- a/runner-sdk/java/flarerunner/src/test/java/com/flaredb/runner/FlareArtifactResolverTest.java
+++ b/runner-sdk/java/flarerunner/src/test/java/com/flaredb/runner/FlareArtifactResolverTest.java
@@ -1,0 +1,125 @@
+package com.flaredb.runner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import org.apache.beam.model.pipeline.v1.RunnerApi;
+import org.apache.beam.sdk.options.PipelineOptions;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.junit.Test;
+
+public class FlareArtifactResolverTest {
+
+  private static PipelineOptions optionsWithUberJar(String path) {
+    FlarePipelineOptions options = PipelineOptionsFactory.as(FlarePipelineOptions.class);
+    options.setUberJar(path);
+    return options;
+  }
+
+  private static File newTempJar() throws IOException {
+    File jar = File.createTempFile("flare-artifact-resolver-test", ".jar");
+    jar.deleteOnExit();
+    return jar;
+  }
+
+  @Test
+  public void constructorThrowsWhenUberJarNotSet() {
+    PipelineOptions options = PipelineOptionsFactory.as(FlarePipelineOptions.class);
+
+    IllegalArgumentException exception =
+        assertThrows(IllegalArgumentException.class, () -> new FlareArtifactResolver(options));
+    assertTrue(exception.getMessage().contains("--uberJar"));
+  }
+
+  @Test
+  public void constructorThrowsWhenUberJarIsEmpty() {
+    PipelineOptions options = optionsWithUberJar("");
+
+    assertThrows(IllegalArgumentException.class, () -> new FlareArtifactResolver(options));
+  }
+
+  @Test
+  public void constructorThrowsWhenUberJarDoesNotExist() {
+    PipelineOptions options = optionsWithUberJar("/no/such/path/app.jar");
+
+    IllegalArgumentException exception =
+        assertThrows(IllegalArgumentException.class, () -> new FlareArtifactResolver(options));
+    assertTrue(exception.getMessage().contains("not found"));
+  }
+
+  @Test
+  public void constructorThrowsWhenUberJarIsADirectory() {
+    PipelineOptions options = optionsWithUberJar(System.getProperty("java.io.tmpdir"));
+
+    IllegalArgumentException exception =
+        assertThrows(IllegalArgumentException.class, () -> new FlareArtifactResolver(options));
+    assertTrue(exception.getMessage().contains("not a file"));
+  }
+
+  @Test
+  public void constructorSucceedsWhenUberJarIsAnExistingFile() throws IOException {
+    File jar = newTempJar();
+
+    new FlareArtifactResolver(optionsWithUberJar(jar.getAbsolutePath()));
+  }
+
+  @Test
+  public void resolveArtifactsWithEmptyListReturnsUberJarArtifact() throws IOException {
+    File jar = newTempJar();
+    FlareArtifactResolver resolver =
+        new FlareArtifactResolver(optionsWithUberJar(jar.getAbsolutePath()));
+
+    List<RunnerApi.ArtifactInformation> resolved =
+        resolver.resolveArtifacts(Collections.emptyList());
+
+    assertEquals(1, resolved.size());
+    RunnerApi.ArtifactInformation artifact = resolved.get(0);
+    assertEquals("beam:artifact:type:file:v1", artifact.getTypeUrn());
+    assertEquals("beam:artifact:role:staging_to:v1", artifact.getRoleUrn());
+
+    RunnerApi.ArtifactFilePayload payload =
+        RunnerApi.ArtifactFilePayload.parseFrom(artifact.getTypePayload());
+    assertEquals(jar.getAbsolutePath(), payload.getPath());
+  }
+
+  @Test
+  public void resolveArtifactsWithNonEmptyListReturnsItUnchanged() throws IOException {
+    File jar = newTempJar();
+    FlareArtifactResolver resolver =
+        new FlareArtifactResolver(optionsWithUberJar(jar.getAbsolutePath()));
+
+    RunnerApi.ArtifactInformation existing =
+        RunnerApi.ArtifactInformation.newBuilder().setTypeUrn("beam:artifact:type:url:v1").build();
+    List<RunnerApi.ArtifactInformation> input = Collections.singletonList(existing);
+
+    List<RunnerApi.ArtifactInformation> resolved = resolver.resolveArtifacts(input);
+
+    assertSame(input, resolved);
+  }
+
+  @Test
+  public void registerIsNotSupported() throws IOException {
+    File jar = newTempJar();
+    FlareArtifactResolver resolver =
+        new FlareArtifactResolver(optionsWithUberJar(jar.getAbsolutePath()));
+
+    assertThrows(UnsupportedOperationException.class, () -> resolver.register(artifact -> null));
+  }
+
+  @Test
+  public void resolveArtifactsForPipelineIsNotSupported() throws IOException {
+    File jar = newTempJar();
+    FlareArtifactResolver resolver =
+        new FlareArtifactResolver(optionsWithUberJar(jar.getAbsolutePath()));
+
+    assertThrows(
+        UnsupportedOperationException.class,
+        () -> resolver.resolveArtifacts(RunnerApi.Pipeline.getDefaultInstance()));
+  }
+}

--- a/runner-sdk/java/flarerunner/src/test/java/com/flaredb/runner/FlarePipelineJobTest.java
+++ b/runner-sdk/java/flarerunner/src/test/java/com/flaredb/runner/FlarePipelineJobTest.java
@@ -1,0 +1,47 @@
+package com.flaredb.runner;
+
+import static org.junit.Assert.assertThrows;
+
+import org.apache.beam.vendor.grpc.v1p69p0.com.google.protobuf.ByteString;
+import org.joda.time.Duration;
+import org.junit.Test;
+
+/**
+ * {@link FlarePipelineJob} currently only carries the submitted job id; every {@link
+ * org.apache.beam.sdk.PipelineResult} operation is documented as unimplemented. These tests pin
+ * down that contract so it fails loudly (rather than silently changing behavior) once monitoring,
+ * cancellation, or metrics support is added.
+ */
+public class FlarePipelineJobTest {
+
+  private static FlarePipelineJob newJob() {
+    return new FlarePipelineJob(ByteString.copyFromUtf8("job-1"));
+  }
+
+  @Test
+  public void getStateIsNotSupported() {
+    assertThrows(UnsupportedOperationException.class, () -> newJob().getState());
+  }
+
+  @Test
+  public void cancelIsNotSupported() {
+    assertThrows(UnsupportedOperationException.class, () -> newJob().cancel());
+  }
+
+  @Test
+  public void waitUntilFinishWithDurationIsNotSupported() {
+    assertThrows(
+        UnsupportedOperationException.class,
+        () -> newJob().waitUntilFinish(Duration.standardSeconds(1)));
+  }
+
+  @Test
+  public void waitUntilFinishIsNotSupported() {
+    assertThrows(UnsupportedOperationException.class, () -> newJob().waitUntilFinish());
+  }
+
+  @Test
+  public void metricsIsNotSupported() {
+    assertThrows(UnsupportedOperationException.class, () -> newJob().metrics());
+  }
+}

--- a/runner-sdk/java/flarerunner/src/test/java/com/flaredb/runner/FlarePipelineOptionsTest.java
+++ b/runner-sdk/java/flarerunner/src/test/java/com/flaredb/runner/FlarePipelineOptionsTest.java
@@ -1,0 +1,48 @@
+package com.flaredb.runner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.util.Arrays;
+import java.util.List;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.junit.Test;
+
+public class FlarePipelineOptionsTest {
+
+  @Test
+  public void uberJarDefaultsToNull() {
+    FlarePipelineOptions options = PipelineOptionsFactory.as(FlarePipelineOptions.class);
+
+    assertNull(options.getUberJar());
+  }
+
+  @Test
+  public void uberJarRoundTripsThroughGetterAndSetter() {
+    FlarePipelineOptions options = PipelineOptionsFactory.as(FlarePipelineOptions.class);
+
+    options.setUberJar("/path/to/app-all.jar");
+
+    assertEquals("/path/to/app-all.jar", options.getUberJar());
+  }
+
+  @Test
+  public void filesToStageRoundTripsThroughGetterAndSetter() {
+    FlarePipelineOptions options = PipelineOptionsFactory.as(FlarePipelineOptions.class);
+    List<String> files = Arrays.asList("a.jar", "b.jar");
+
+    options.setFilesToStage(files);
+
+    assertEquals(files, options.getFilesToStage());
+  }
+
+  @Test
+  public void optionsAreCreatedFromCommandLineArgs() {
+    FlarePipelineOptions options =
+        PipelineOptionsFactory.fromArgs("--uberJar=/tmp/app.jar", "--jobEndpoint=localhost:8099")
+            .as(FlarePipelineOptions.class);
+
+    assertEquals("/tmp/app.jar", options.getUberJar());
+    assertEquals("localhost:8099", options.getJobEndpoint());
+  }
+}


### PR DESCRIPTION
## What

Adds unit tests for `runner-sdk/java/flarerunner`, which currently has no test coverage at all (the sibling `flareio-java` module already has tests, this one didn't).

- **`FlareArtifactResolverTest`** — covers the constructor's uber-jar validation (missing option, empty string, nonexistent path, path is a directory, valid file) and `resolveArtifacts` behavior (synthesizes an artifact from the configured jar when given an empty list, passes a non-empty list through unchanged), plus the two currently-unsupported `ArtifactResolver` methods.
- **`FlarePipelineOptionsTest`** — verifies the `FlarePipelineOptions` getter/setter contract (`uberJar`, `filesToStage`) and that options parse correctly via `PipelineOptionsFactory.fromArgs`.
- **`FlarePipelineJobTest`** — pins down that every `PipelineResult` method on `FlarePipelineJob` throws `UnsupportedOperationException` as documented, so it's caught loudly rather than silently if that changes.

No production code changes — only `runner-sdk/java/flarerunner/build.gradle` gained a `testImplementation libs.junit` line (the module had no test dependency declared), matching how `flareio-java` is already set up.

## Why

`FlareArtifactResolver` in particular has real validation logic (throws on missing/empty/nonexistent/non-file jar paths) that was previously unverified by any test — a regression there would only surface at pipeline-submission time against a live FlareDB instance.

## Test plan

```
./gradlew :flaredb-runner:test
./gradlew :flaredb-runner:spotlessCheck
./gradlew build -x test
```

All pass locally (18 new tests, all green).